### PR TITLE
pin importlib_metadata package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.46.0
 h11==0.9.0
 httptools==0.0.13
 idna==2.8
-importlib-metadata==1.3.0
+importlib_metadata==1.6.0  # from kombu
 kombu==4.6.11
 more-itertools==8.0.2
 multidict==4.7.3


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version